### PR TITLE
Allow setting custom header and page_header

### DIFF
--- a/fastapi_admin/site.py
+++ b/fastapi_admin/site.py
@@ -43,7 +43,6 @@ class Site(BaseModel):
     login_logo: Optional[HttpUrl]
     login_footer: Optional[str]
     login_description: Optional[str]
-    footer: Optional[str]
     locale: str
     locale_switcher: bool = False
     theme_switcher: bool = False
@@ -55,7 +54,9 @@ class Site(BaseModel):
     menus: Optional[List[Menu]]
     # custom footer with html
     footer: Optional[str]
-
+    # custom header - require html beginning with a <div> due to being rendered in a <custom-component>
+    header: Optional[str]
+    page_header: Optional[str]
 
 class Field(BaseModel):
     label: str


### PR DESCRIPTION
Allow optional custom `header` and `page_header` settings for `class Site(BaseModel):`
header need to be a string with html looking like `<div>CUSTOM_HEADER</div>` due to how its rendered in frontend

Also, removed duplicate footer parameter in `class Site(BaseModel):` definition.